### PR TITLE
Add ransomware quiz call-to-action and assessment page

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d47a1"/>
+      <stop offset="100%" stop-color="#1976d2"/>
+    </linearGradient>
+    <linearGradient id="shieldHighlight" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#e53935"/>
+      <stop offset="100%" stop-color="#b71c1c"/>
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <path d="M128 14l96 32v72c0 50.897-39.704 97.85-96 124-56.296-26.15-96-73.103-96-124V46l96-32z" fill="#111827"/>
+    <path d="M128 28l80 26.666V118c0 43.722-34.19 84.03-80 105.81-45.81-21.78-80-62.088-80-105.81V54.666L128 28z" fill="#f9fafb"/>
+    <path d="M128 48l60 20v52c0 34.519-25.273 66.661-60 84-34.727-17.339-60-49.481-60-84V68l60-20z" fill="#111827"/>
+    <path d="M128 14l96 32v0l-22 7.333-74-23.333-74 23.333L32 46l96-32z" fill="#1f2937"/>
+    <path d="M128 28l-80 26.667V54.666L128 28z" fill="url(#shieldGradient)"/>
+    <path d="M128 28l80 26.667V54.666L128 28z" fill="url(#shieldHighlight)"/>
+    <rect x="104" y="88" width="48" height="72" rx="12" fill="#f9fafb"/>
+    <path d="M152 120v32a24 24 0 11-48 0v-32h48zm-24-32c8.837 0 16 7.163 16 16v16h-32v-16c0-8.837 7.163-16 16-16z" fill="#111827"/>
+    <circle cx="128" cy="148" r="12" fill="#e53935"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,725 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>What is Ransomware — Cybersecurity Awareness Project</title>
+    <meta
+      name="description"
+      content="What is Ransomware is a free cybersecurity awareness project offering practical education, readiness tools, and response guidance for individuals and organizations."
+    />
+    <link rel="preload" href="assets/logo.svg" as="image" type="image/svg+xml" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg-dark: #0b1220;
+        --bg-muted: #111a2e;
+        --bg-panel: rgba(255, 255, 255, 0.06);
+        --accent-red: #f64a4a;
+        --accent-blue: #3b82f6;
+        --accent-cyan: #22d3ee;
+        --text-primary: #f9fafb;
+        --text-muted: #cbd5f5;
+        --shadow-lg: 0 30px 60px -25px rgba(0, 0, 0, 0.6);
+        --shadow-sm: 0 12px 25px -15px rgba(15, 23, 42, 0.8);
+        font-family: 'Segoe UI', 'Inter', system-ui, -apple-system, sans-serif;
+      }
 
+      * {
+        box-sizing: border-box;
+        margin: 0;
+      }
+
+      body {
+        background: radial-gradient(circle at 20% 20%, rgba(34, 211, 238, 0.12), transparent 50%),
+          radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.18), transparent 55%),
+          linear-gradient(135deg, var(--bg-dark), #030712);
+        color: var(--text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      header {
+        padding: 1.25rem 0;
+      }
+
+      .container {
+        width: min(1200px, 92vw);
+        margin: 0 auto;
+      }
+
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        text-decoration: none;
+        color: inherit;
+      }
+
+      .brand img {
+        width: 58px;
+        height: 58px;
+        filter: drop-shadow(0 18px 24px rgba(2, 12, 27, 0.6));
+      }
+
+      .brand span {
+        display: grid;
+      }
+
+      .brand strong {
+        font-size: 1.05rem;
+        letter-spacing: 0.1em;
+      }
+
+      .brand small {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        opacity: 0.75;
+      }
+
+      .cta-group {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        border: none;
+        border-radius: 999px;
+        padding: 0.85rem 1.6rem;
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-size: 0.95rem;
+        transition: transform 0.2s ease, box-shadow 0.3s ease, background 0.3s ease;
+        text-decoration: none;
+      }
+
+      .btn-primary {
+        background: linear-gradient(135deg, #2563eb, #7c3aed);
+        color: white;
+        box-shadow: 0 18px 38px -18px rgba(59, 130, 246, 0.8);
+      }
+
+      .btn-secondary {
+        background: rgba(15, 23, 42, 0.65);
+        color: var(--text-muted);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+      }
+
+      .btn-quiz {
+        background: linear-gradient(135deg, #f97316, #ef4444);
+        color: white;
+        box-shadow: 0 18px 38px -18px rgba(239, 68, 68, 0.8);
+      }
+
+      .btn:hover {
+        transform: translateY(-3px);
+      }
+
+      main {
+        display: grid;
+        gap: 6rem;
+        padding-bottom: 6rem;
+      }
+
+      section {
+        position: relative;
+      }
+
+      .hero {
+        margin-top: 3.5rem;
+        display: grid;
+        gap: 3rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        align-items: center;
+      }
+
+      .hero h1 {
+        font-size: clamp(2.4rem, 3vw + 2rem, 3.75rem);
+        line-height: 1.1;
+        margin-bottom: 1.5rem;
+        text-shadow: 0 18px 28px rgba(3, 7, 18, 0.8);
+      }
+
+      .hero p {
+        font-size: 1.05rem;
+        color: var(--text-muted);
+        margin-bottom: 2rem;
+        max-width: 540px;
+      }
+
+      .hero-card {
+        background: linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.65));
+        border-radius: 26px;
+        padding: 2.5rem;
+        box-shadow: var(--shadow-lg);
+        border: 1px solid rgba(148, 163, 184, 0.22);
+        backdrop-filter: blur(16px);
+      }
+
+      .hero-card h2 {
+        text-transform: uppercase;
+        letter-spacing: 0.22em;
+        font-size: 0.85rem;
+        color: var(--accent-cyan);
+        margin-bottom: 1.25rem;
+      }
+
+      .insight-grid {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .insight {
+        padding: 1.5rem;
+        border-radius: 18px;
+        background: rgba(15, 23, 42, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: var(--shadow-sm);
+      }
+
+      .insight strong {
+        font-size: 1.5rem;
+        color: var(--accent-cyan);
+      }
+
+      .section-title {
+        font-size: clamp(2rem, 2vw + 1.5rem, 2.6rem);
+        margin-bottom: 2rem;
+      }
+
+      .section-title span {
+        color: var(--accent-red);
+      }
+
+      .content-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+
+      .card {
+        background: rgba(11, 18, 32, 0.75);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 22px;
+        padding: 1.75rem;
+        box-shadow: var(--shadow-sm);
+        transition: transform 0.3s ease;
+        backdrop-filter: blur(12px);
+      }
+
+      .card:hover {
+        transform: translateY(-6px);
+      }
+
+      .card h3 {
+        margin-bottom: 0.75rem;
+        font-size: 1.25rem;
+      }
+
+      .card p {
+        color: var(--text-muted);
+        font-size: 0.98rem;
+      }
+
+      .stat-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .stat-card {
+        background: rgba(15, 23, 42, 0.65);
+        border-radius: 20px;
+        padding: 1.75rem;
+        border: 1px solid rgba(59, 130, 246, 0.25);
+        box-shadow: var(--shadow-sm);
+      }
+
+      .stat-card strong {
+        font-size: 2.2rem;
+        display: block;
+        margin-bottom: 0.35rem;
+        color: var(--accent-blue);
+      }
+
+      .timeline {
+        position: relative;
+        padding-left: 1.5rem;
+        display: grid;
+        gap: 1.75rem;
+      }
+
+      .timeline::before {
+        content: '';
+        position: absolute;
+        left: 8px;
+        top: 0;
+        bottom: 0;
+        width: 2px;
+        background: linear-gradient(180deg, rgba(59, 130, 246, 0.6), rgba(226, 232, 240, 0));
+      }
+
+      .timeline-step {
+        position: relative;
+        padding-left: 1.75rem;
+      }
+
+      .timeline-step::before {
+        content: '';
+        position: absolute;
+        left: -1.5rem;
+        top: 0.45rem;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        border: 2px solid var(--accent-blue);
+        background: var(--bg-dark);
+        box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.2);
+      }
+
+      .timeline-step h4 {
+        margin-bottom: 0.4rem;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.4rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(59, 130, 246, 0.12);
+        color: var(--accent-cyan);
+        font-size: 0.78rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin-bottom: 0.75rem;
+      }
+
+      .faq {
+        display: grid;
+        gap: 1rem;
+      }
+
+      details {
+        background: rgba(11, 18, 32, 0.7);
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 1.2rem 1.5rem;
+        transition: border 0.2s ease;
+      }
+
+      details[open] {
+        border-color: rgba(59, 130, 246, 0.5);
+      }
+
+      summary {
+        cursor: pointer;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      summary::after {
+        content: '+';
+        font-size: 1.3rem;
+        transition: transform 0.3s ease;
+      }
+
+      details[open] summary::after {
+        transform: rotate(45deg);
+      }
+
+      footer {
+        border-top: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 3rem 0 4rem;
+        background: rgba(2, 6, 23, 0.7);
+      }
+
+      footer p {
+        color: rgba(226, 232, 240, 0.55);
+      }
+
+      .resource-list {
+        list-style: none;
+        display: grid;
+        gap: 1rem;
+        margin-top: 1.25rem;
+      }
+
+      .resource-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        padding: 1.1rem 1.3rem;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .resource-item span {
+        background: rgba(59, 130, 246, 0.18);
+        color: var(--accent-blue);
+        font-weight: 700;
+        width: 36px;
+        height: 36px;
+        display: grid;
+        place-items: center;
+        border-radius: 50%;
+      }
+
+      form {
+        display: grid;
+        gap: 1rem;
+        margin-top: 1.5rem;
+      }
+
+      label {
+        font-size: 0.9rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--text-muted);
+      }
+
+      input, textarea {
+        background: rgba(15, 23, 42, 0.8);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 12px;
+        padding: 0.85rem 1rem;
+        color: var(--text-primary);
+        font-size: 0.95rem;
+        font-family: inherit;
+      }
+
+      input:focus, textarea:focus {
+        outline: none;
+        border-color: rgba(34, 211, 238, 0.55);
+        box-shadow: 0 0 0 4px rgba(34, 211, 238, 0.12);
+      }
+
+      textarea {
+        min-height: 120px;
+      }
+
+      .grid-two {
+        display: grid;
+        gap: 2rem;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .pill-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        margin-top: 1rem;
+      }
+
+      .pill {
+        padding: 0.5rem 0.9rem;
+        border-radius: 999px;
+        background: rgba(59, 130, 246, 0.18);
+        color: var(--text-muted);
+        font-size: 0.85rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      @media (max-width: 720px) {
+        nav {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .hero {
+          margin-top: 2rem;
+        }
+
+        footer {
+          text-align: center;
+        }
+
+        footer .container {
+          display: grid;
+          gap: 1.5rem;
+          justify-items: center;
+        }
+
+        .resource-item {
+          flex-direction: column;
+          text-align: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="container">
+        <nav>
+          <a class="brand" href="#top">
+            <img src="assets/logo.svg" alt="What is Ransomware logo" />
+            <span>
+              <strong>WHAT IS RANSOMWARE</strong>
+              <small>Cybersecurity Awareness Project</small>
+            </span>
+          </a>
+          <div class="cta-group">
+            <button class="btn btn-secondary" type="button" onclick="document.getElementById('playbook').scrollIntoView({behavior: 'smooth'})">
+              Explore Playbook
+            </button>
+            <button class="btn btn-primary" type="button" onclick="document.getElementById('newsletter').scrollIntoView({behavior: 'smooth'})">
+              Get Updates
+            </button>
+          </div>
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <section class="container hero" aria-labelledby="hero-title">
+        <div>
+          <h1 id="hero-title">Understand, Prevent &amp; Respond to Modern Ransomware Attacks</h1>
+          <p>
+            What is Ransomware empowers individuals, small businesses, educators, and community leaders with the knowledge and tools to identify threats, strengthen defenses, and respond with confidence.
+          </p>
+          <div class="cta-group">
+            <button class="btn btn-primary" type="button" onclick="document.getElementById('learning-hub').scrollIntoView({behavior: 'smooth'})">Start Learning</button>
+            <button class="btn btn-secondary" type="button" onclick="document.getElementById('faq').scrollIntoView({behavior: 'smooth'})">Common Questions</button>
+            <a class="btn btn-quiz" href="quiz.html">Take the Ransomware Quiz</a>
+          </div>
+        </div>
+        <article class="hero-card" aria-labelledby="hero-card-title">
+          <h2 id="hero-card-title">Threat Briefing</h2>
+          <div class="insight-grid">
+            <div class="insight">
+              <strong>+95%</strong>
+              <p>increase in ransomware attacks targeting public sector and education organizations in the last two years.</p>
+            </div>
+            <div class="insight">
+              <strong>80%</strong>
+              <p>of successful ransomware events start with a phishing email or social engineering tactic against employees.</p>
+            </div>
+            <div class="insight">
+              <strong>23 Days</strong>
+              <p>average downtime for organizations that do not have an incident response plan or tested backups in place.</p>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section class="container" id="mission" aria-labelledby="mission-title">
+        <div class="badge">Our mission</div>
+        <h2 class="section-title" id="mission-title">Free, action-ready education for <span>every defender</span></h2>
+        <div class="grid-two">
+          <p>
+            Ransomware criminals exploit gaps in awareness, human error, and unpatched systems. We make complex cybersecurity principles approachable so you can build a resilient defense strategy without needing a full-time security team.
+          </p>
+          <p>
+            From understanding how attackers operate to practicing incident response, our modular learning paths and downloadable resources are designed for classrooms, boardrooms, and home offices alike.
+          </p>
+        </div>
+        <div class="pill-list" role="list">
+          <span class="pill" role="listitem">Individuals</span>
+          <span class="pill" role="listitem">Small &amp; Medium Businesses</span>
+          <span class="pill" role="listitem">IT &amp; Helpdesk Teams</span>
+          <span class="pill" role="listitem">Educators</span>
+          <span class="pill" role="listitem">Community Leaders</span>
+        </div>
+      </section>
+
+      <section class="container" id="attack-surface" aria-labelledby="attack-title">
+        <h2 class="section-title" id="attack-title">How ransomware gangs <span>gain access</span></h2>
+        <div class="content-grid">
+          <article class="card">
+            <h3>Phishing &amp; Social Engineering</h3>
+            <p>Deceptive emails, texts, and voice calls trick users into sharing credentials or running malicious attachments. Spot warning signs like urgent tone, mismatched addresses, and suspicious links.</p>
+          </article>
+          <article class="card">
+            <h3>Exposed Remote Services</h3>
+            <p>Attackers brute force weak passwords or exploit vulnerabilities in VPNs, RDP, and remote management tools. Require multi-factor authentication and restrict access to known networks.</p>
+          </article>
+          <article class="card">
+            <h3>Third-Party &amp; Supply Chain</h3>
+            <p>Compromised vendors and software updates can be weaponized to deliver ransomware. Review vendor security posture, monitor updates, and limit third-party privileges.</p>
+          </article>
+          <article class="card">
+            <h3>Unpatched Systems</h3>
+            <p>Outdated operating systems, firmware, and security tools are easy targets. Schedule regular updates, automate patch deployment, and remove unsupported assets.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="container" id="stats" aria-labelledby="stats-title">
+        <h2 class="section-title" id="stats-title">Key risk signals to track</h2>
+        <div class="stat-grid">
+          <article class="stat-card">
+            <strong>72%</strong>
+            <p>of organizations with immutable backups recovered in less than a week.</p>
+          </article>
+          <article class="stat-card">
+            <strong>43%</strong>
+            <p>of attacks now include data extortion in addition to encryption.</p>
+          </article>
+          <article class="stat-card">
+            <strong>4 hrs</strong>
+            <p>Average time it takes for ransomware to begin encrypting once an attacker has foothold.</p>
+          </article>
+          <article class="stat-card">
+            <strong>3x</strong>
+            <p>increase in attacks against managed service providers and IT consultancies year-over-year.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="container" id="playbook" aria-labelledby="playbook-title">
+        <div class="badge">Incident response playbook</div>
+        <h2 class="section-title" id="playbook-title">Respond with <span>precision</span> when minutes matter</h2>
+        <div class="timeline" role="list">
+          <article class="timeline-step card" role="listitem">
+            <h4>1. Detect &amp; Contain</h4>
+            <p>Isolate affected devices from the network, disable shared drives, and preserve evidence. Activate monitoring to spot lateral movement attempts.</p>
+          </article>
+          <article class="timeline-step card" role="listitem">
+            <h4>2. Assess Impact</h4>
+            <p>Document affected systems, data sensitivity, and business processes. Engage legal and compliance leads to evaluate reporting obligations.</p>
+          </article>
+          <article class="timeline-step card" role="listitem">
+            <h4>3. Eradicate &amp; Recover</h4>
+            <p>Remove malicious persistence, reset credentials, and restore clean backups. Validate system integrity before reconnecting to production networks.</p>
+          </article>
+          <article class="timeline-step card" role="listitem">
+            <h4>4. Learn &amp; Improve</h4>
+            <p>Conduct a blameless post-incident review, capture lessons learned, and strengthen controls, user training, and detection engineering.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="container" id="learning-hub" aria-labelledby="learning-title">
+        <div class="badge">Learning hub</div>
+        <h2 class="section-title" id="learning-title">Build your <span>skills pathway</span></h2>
+        <div class="content-grid">
+          <article class="card">
+            <h3>Foundations Track</h3>
+            <p>Understand ransomware anatomy, attacker motivations, and defensive layers. Ideal for students, citizens, and business owners starting their security journey.</p>
+          </article>
+          <article class="card">
+            <h3>Policy &amp; Leadership Track</h3>
+            <p>Develop governance frameworks, risk assessments, and executive playbooks to guide strategic decision-making during high-pressure events.</p>
+          </article>
+          <article class="card">
+            <h3>Technical Defense Track</h3>
+            <p>Hands-on labs exploring endpoint hardening, SIEM alerts, zero trust segmentation, and backup validation to minimize attacker dwell time.</p>
+          </article>
+          <article class="card">
+            <h3>Educator Toolkit</h3>
+            <p>Lesson plans, slide decks, and classroom simulations that bring ransomware scenarios to life and encourage proactive security habits.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="container" id="toolkit" aria-labelledby="toolkit-title">
+        <div class="badge">Downloadable toolkit</div>
+        <h2 class="section-title" id="toolkit-title">Templates &amp; checklists to <span>put knowledge into action</span></h2>
+        <ul class="resource-list">
+          <li class="resource-item">
+            <span>1</span>
+            <div>
+              <h3>Ransomware Readiness Checklist</h3>
+              <p>Use this monthly checklist to validate offline backups, update incident contacts, and ensure security awareness training is on schedule.</p>
+            </div>
+          </li>
+          <li class="resource-item">
+            <span>2</span>
+            <div>
+              <h3>Executive Brief Template</h3>
+              <p>Communicate clearly with leadership using a concise brief that covers impact, response timeline, and resource requirements.</p>
+            </div>
+          </li>
+          <li class="resource-item">
+            <span>3</span>
+            <div>
+              <h3>Tabletop Exercise Guide</h3>
+              <p>Run realistic tabletop drills with technical and non-technical stakeholders to test decision-making and coordination.</p>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <section class="container" id="simulation" aria-labelledby="simulation-title">
+        <div class="badge">Scenario spotlight</div>
+        <h2 class="section-title" id="simulation-title">Walk through a <span>day-one ransomware scenario</span></h2>
+        <div class="card">
+          <h3>Interactive Response Drill</h3>
+          <p>Follow a fictional organization facing a ransomware attack. Identify suspicious behaviors, choose response actions, and see how decisions change the outcome. Use it as a workshop or self-paced learning module.</p>
+        </div>
+      </section>
+
+      <section class="container" id="faq" aria-labelledby="faq-title">
+        <div class="badge">FAQ</div>
+        <h2 class="section-title" id="faq-title">Answers to your <span>most common questions</span></h2>
+        <div class="faq">
+          <details>
+            <summary>Should we ever pay the ransom?</summary>
+            <p>Paying ransom is risky and often discouraged by law enforcement. Even after payment, decryption tools may fail and attackers can still leak stolen data. Focus on prevention, backups, and legal consultation to make an informed decision.</p>
+          </details>
+          <details>
+            <summary>How do we protect remote and hybrid workers?</summary>
+            <p>Require multi-factor authentication, limit admin privileges, ensure VPN or zero trust network access, and deliver just-in-time phishing simulations tailored for remote teams.</p>
+          </details>
+          <details>
+            <summary>What regulations apply after an incident?</summary>
+            <p>Reporting obligations vary by region and industry. Engage legal counsel early to understand requirements such as GDPR, HIPAA, SEC disclosures, and state-specific breach notification laws.</p>
+          </details>
+          <details>
+            <summary>How often should we test backups?</summary>
+            <p>Test restoration quarterly at a minimum, with critical systems validated monthly. Include verification that backups are isolated, versioned, and encrypted.</p>
+          </details>
+        </div>
+      </section>
+
+      <section class="container" id="newsletter" aria-labelledby="newsletter-title">
+        <div class="badge">Stay informed</div>
+        <h2 class="section-title" id="newsletter-title">Join our <span>ransomware resilience briefing</span></h2>
+        <div class="grid-two">
+          <p>
+            Subscribe to monthly insights featuring emerging threat intelligence, defensive playbooks, and training events you can share with your network. We respect your inbox—no spam, only actionable knowledge.
+          </p>
+          <form>
+            <div>
+              <label for="email">Email address</label>
+              <input id="email" type="email" name="email" placeholder="you@example.com" required />
+            </div>
+            <div>
+              <label for="role">Your role</label>
+              <input id="role" type="text" name="role" placeholder="Security Analyst, Teacher, Business Owner..." />
+            </div>
+            <button class="btn btn-primary" type="submit">Subscribe for updates</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container">
+        <p>
+          © <span id="year"></span> What is Ransomware — Cybersecurity Awareness Project. Built to educate and empower communities against cyber extortion.
+        </p>
+      </div>
+    </footer>
+
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/quiz.html
+++ b/quiz.html
@@ -1,0 +1,664 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ransomware Readiness Quiz — What is Ransomware</title>
+    <meta
+      name="description"
+      content="Test your knowledge of ransomware threats, prevention, and response with this ten-question quiz from the What is Ransomware education project."
+    />
+    <link rel="preload" href="assets/logo.svg" as="image" type="image/svg+xml" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg-dark: #0b1220;
+        --bg-muted: #111a2e;
+        --bg-panel: rgba(255, 255, 255, 0.06);
+        --accent-red: #f64a4a;
+        --accent-blue: #3b82f6;
+        --accent-cyan: #22d3ee;
+        --text-primary: #f9fafb;
+        --text-muted: #cbd5f5;
+        --shadow-lg: 0 30px 60px -25px rgba(0, 0, 0, 0.6);
+        --shadow-sm: 0 12px 25px -15px rgba(15, 23, 42, 0.8);
+        font-family: 'Segoe UI', 'Inter', system-ui, -apple-system, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+      }
+
+      body {
+        background: radial-gradient(circle at 20% 20%, rgba(34, 211, 238, 0.12), transparent 50%),
+          radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.18), transparent 55%),
+          linear-gradient(135deg, var(--bg-dark), #030712);
+        color: var(--text-primary);
+        min-height: 100vh;
+        line-height: 1.6;
+      }
+
+      header {
+        padding: 1.25rem 0;
+      }
+
+      .container {
+        width: min(1200px, 92vw);
+        margin: 0 auto;
+      }
+
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        text-decoration: none;
+        color: inherit;
+      }
+
+      .brand img {
+        width: 58px;
+        height: 58px;
+        filter: drop-shadow(0 18px 24px rgba(2, 12, 27, 0.6));
+      }
+
+      .brand span {
+        display: grid;
+      }
+
+      .brand strong {
+        font-size: 1.05rem;
+        letter-spacing: 0.1em;
+      }
+
+      .brand small {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        opacity: 0.75;
+      }
+
+      .cta-group {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        border: none;
+        border-radius: 999px;
+        padding: 0.85rem 1.6rem;
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-size: 0.95rem;
+        transition: transform 0.2s ease, box-shadow 0.3s ease, background 0.3s ease;
+        text-decoration: none;
+      }
+
+      .btn-primary {
+        background: linear-gradient(135deg, #2563eb, #7c3aed);
+        color: white;
+        box-shadow: 0 18px 38px -18px rgba(59, 130, 246, 0.8);
+      }
+
+      .btn-secondary {
+        background: rgba(15, 23, 42, 0.65);
+        color: var(--text-muted);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+      }
+
+      .btn-quiz {
+        background: linear-gradient(135deg, #f97316, #ef4444);
+        color: white;
+        box-shadow: 0 18px 38px -18px rgba(239, 68, 68, 0.8);
+      }
+
+      .btn:hover {
+        transform: translateY(-3px);
+      }
+
+      main {
+        display: grid;
+        gap: 4.5rem;
+        padding-bottom: 5rem;
+      }
+
+      .quiz-hero {
+        margin-top: 3.5rem;
+        display: grid;
+        gap: 2rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        align-items: center;
+      }
+
+      .quiz-hero h1 {
+        font-size: clamp(2.2rem, 3vw + 1.8rem, 3.4rem);
+        line-height: 1.1;
+        margin-bottom: 1.25rem;
+        text-shadow: 0 18px 28px rgba(3, 7, 18, 0.8);
+      }
+
+      .quiz-hero p {
+        font-size: 1.05rem;
+        color: var(--text-muted);
+        max-width: 560px;
+      }
+
+      .quiz-highlight {
+        background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.7));
+        border-radius: 24px;
+        padding: 2.4rem;
+        border: 1px solid rgba(148, 163, 184, 0.22);
+        box-shadow: var(--shadow-lg);
+      }
+
+      .quiz-highlight ul {
+        display: grid;
+        gap: 0.85rem;
+        padding-left: 1.2rem;
+        color: var(--text-muted);
+      }
+
+      .quiz-section h2 {
+        font-size: clamp(2rem, 2vw + 1.6rem, 2.75rem);
+        margin-bottom: 1rem;
+      }
+
+      .quiz-section > p {
+        color: var(--text-muted);
+        margin-bottom: 2rem;
+      }
+
+      form {
+        display: grid;
+        gap: 2rem;
+      }
+
+      .quiz-grid {
+        display: grid;
+        gap: 1.75rem;
+      }
+
+      .quiz-card {
+        background: rgba(15, 23, 42, 0.75);
+        border-radius: 22px;
+        padding: 1.75rem;
+        border: 1px solid rgba(148, 163, 184, 0.16);
+        box-shadow: var(--shadow-sm);
+        transition: border 0.25s ease, transform 0.2s ease;
+      }
+
+      .quiz-card.is-correct {
+        border-color: rgba(34, 197, 94, 0.8);
+      }
+
+      .quiz-card.is-incorrect {
+        border-color: rgba(239, 68, 68, 0.85);
+      }
+
+      fieldset {
+        border: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 1rem;
+      }
+
+      legend {
+        font-weight: 700;
+        font-size: 1.05rem;
+        margin-bottom: 0.5rem;
+      }
+
+      legend span {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 34px;
+        height: 34px;
+        border-radius: 999px;
+        background: rgba(59, 130, 246, 0.18);
+        color: var(--accent-blue);
+        font-size: 0.9rem;
+        margin-right: 0.65rem;
+      }
+
+      .option {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+        background: rgba(11, 18, 32, 0.8);
+        padding: 0.9rem 1rem;
+        border-radius: 16px;
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition: border 0.2s ease, background 0.2s ease;
+      }
+
+      .option:hover,
+      .option:focus-within {
+        border-color: rgba(59, 130, 246, 0.45);
+        background: rgba(17, 26, 46, 0.95);
+      }
+
+      .option input {
+        margin-top: 0.3rem;
+        accent-color: #3b82f6;
+      }
+
+      .option span {
+        color: var(--text-muted);
+      }
+
+      .feedback {
+        min-height: 1.25rem;
+        font-size: 0.95rem;
+        margin-top: 0.6rem;
+      }
+
+      .feedback.correct {
+        color: #34d399;
+      }
+
+      .feedback.incorrect {
+        color: #fca5a5;
+      }
+
+      .feedback.pending {
+        color: var(--text-muted);
+      }
+
+      .quiz-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+
+      #quiz-result {
+        font-size: 1.05rem;
+        color: var(--text-muted);
+      }
+
+      footer {
+        padding: 3rem 0 4rem;
+        text-align: center;
+        color: var(--text-muted);
+      }
+
+      @media (max-width: 720px) {
+        legend {
+          font-size: 1rem;
+        }
+
+        .quiz-card {
+          padding: 1.45rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="container">
+        <nav>
+          <a class="brand" href="index.html">
+            <img src="assets/logo.svg" alt="What is Ransomware logo" />
+            <span>
+              <strong>WHAT IS RANSOMWARE</strong>
+              <small>Cybersecurity Awareness Project</small>
+            </span>
+          </a>
+          <div class="cta-group">
+            <a class="btn btn-secondary" href="index.html#learning-hub">Back to Learning Hub</a>
+            <a class="btn btn-quiz" href="#quiz">Start the Quiz</a>
+          </div>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="container quiz-hero">
+        <div>
+          <h1>Ransomware Readiness Quiz</h1>
+          <p>
+            Measure your knowledge of how ransomware operates, how to spot attacks, and which response steps matter most. Use the questions below to identify strengths and gaps, then revisit the learning hub for deeper practice.
+          </p>
+        </div>
+        <aside class="quiz-highlight">
+          <h2 style="margin-bottom: 1rem">How to use this quiz</h2>
+          <ul>
+            <li>Select the best answer for each question—there's only one correct choice.</li>
+            <li>Click <strong>Check my answers</strong> to see your score and explanations.</li>
+            <li>Look for the green and red highlights to spot strengths and areas to review.</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section class="container quiz-section" id="quiz" aria-labelledby="quiz-heading">
+        <h2 id="quiz-heading">10 questions to test your ransomware response skills</h2>
+        <p>Answer every question to reveal your score. Aim for 8 or more correct responses to demonstrate strong readiness.</p>
+        <form id="quiz-form">
+          <div class="quiz-grid">
+            <article class="quiz-card" data-answer="b" data-explanation="Ransomware encrypts valuable data and demands payment for the decryption key, disrupting victims until they comply.">
+              <fieldset>
+                <legend><span>1</span>What is the primary objective of most ransomware attacks?</legend>
+                <label class="option">
+                  <input type="radio" name="question1" value="a" />
+                  <span>Steal hardware devices from the victim organization.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question1" value="b" />
+                  <span>Encrypt critical data and demand payment to restore access.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question1" value="c" />
+                  <span>Monitor network traffic to gather competitive intelligence.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question1" value="d" />
+                  <span>Install legitimate software updates across the environment.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="b" data-explanation="Phishing emails trick users into opening malicious attachments or links that deliver ransomware payloads.">
+              <fieldset>
+                <legend><span>2</span>Which action most commonly enables ransomware to enter a network?</legend>
+                <label class="option">
+                  <input type="radio" name="question2" value="a" />
+                  <span>Ignoring browser pop-up advertisements.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question2" value="b" />
+                  <span>Clicking on a malicious email attachment or link.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question2" value="c" />
+                  <span>Using multi-factor authentication on remote access tools.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question2" value="d" />
+                  <span>Viewing files in read-only mode.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="c" data-explanation="Offline or offsite backups remain out of reach for attackers, giving responders a clean copy for recovery.">
+              <fieldset>
+                <legend><span>3</span>Why are offline or offsite backups recommended in ransomware defense plans?</legend>
+                <label class="option">
+                  <input type="radio" name="question3" value="a" />
+                  <span>They make it easier for attackers to locate sensitive data.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question3" value="b" />
+                  <span>They allow employees to skip patching endpoints.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question3" value="c" />
+                  <span>They stay out of reach if attackers encrypt production systems.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question3" value="d" />
+                  <span>They automatically notify law enforcement when accessed.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="c" data-explanation="Disconnecting compromised hosts limits the ransomware's ability to spread before responders analyze the scope.">
+              <fieldset>
+                <legend><span>4</span>What should be the first response after confirming ransomware on a workstation?</legend>
+                <label class="option">
+                  <input type="radio" name="question4" value="a" />
+                  <span>Immediately power the computer off without telling anyone.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question4" value="b" />
+                  <span>Pay the ransom to restore operations as quickly as possible.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question4" value="c" />
+                  <span>Isolate the affected system from the network and report the incident.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question4" value="d" />
+                  <span>Delete suspicious files to clean up the machine.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="b" data-explanation="Suddenly renamed or unreadable files indicate encryption already started, a hallmark of ransomware.">
+              <fieldset>
+                <legend><span>5</span>Which warning sign suggests a ransomware attack is already underway?</legend>
+                <label class="option">
+                  <input type="radio" name="question5" value="a" />
+                  <span>Multi-factor authentication prompts appearing unexpectedly.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question5" value="b" />
+                  <span>Files gaining strange extensions and becoming unreadable.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question5" value="c" />
+                  <span>Internet connections speeding up dramatically.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question5" value="d" />
+                  <span>Security patches installing successfully overnight.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="c" data-explanation="Double extortion means attackers both encrypt and steal data so they can threaten public leaks if payment is refused.">
+              <fieldset>
+                <legend><span>6</span>What is meant by “double extortion” in modern ransomware campaigns?</legend>
+                <label class="option">
+                  <input type="radio" name="question6" value="a" />
+                  <span>Using two different encryption algorithms on the same files.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question6" value="b" />
+                  <span>Contacting victims by phone and email at the same time.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question6" value="c" />
+                  <span>Stealing data before encryption to threaten public exposure.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question6" value="d" />
+                  <span>Charging two separate ransom amounts for one attack.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="c" data-explanation="Limiting accounts to the minimum necessary privileges reduces the blast radius if credentials are compromised.">
+              <fieldset>
+                <legend><span>7</span>Which user access practice best reduces ransomware risk?</legend>
+                <label class="option">
+                  <input type="radio" name="question7" value="a" />
+                  <span>Reusing passwords across multiple business systems.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question7" value="b" />
+                  <span>Allowing all staff to install any software they choose.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question7" value="c" />
+                  <span>Enforcing least-privilege access for each role.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question7" value="d" />
+                  <span>Sharing administrative accounts to simplify support.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="b" data-explanation="Paying a ransom finances criminal operations and offers no guarantee that stolen or encrypted data will be restored.">
+              <fieldset>
+                <legend><span>8</span>Why do security agencies discourage paying a ransomware demand?</legend>
+                <label class="option">
+                  <input type="radio" name="question8" value="a" />
+                  <span>Payments are always refunded by the attacker after decryption.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question8" value="b" />
+                  <span>There is no assurance of recovery and it funds future attacks.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question8" value="c" />
+                  <span>Paying a ransom is illegal in every country.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question8" value="d" />
+                  <span>Attackers usually request payment in physical gift cards.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="d" data-explanation="Endpoint detection and response tools monitor systems continuously to spot suspicious behavior and trigger rapid containment.">
+              <fieldset>
+                <legend><span>9</span>Which technology helps security teams identify ransomware activity early?</legend>
+                <label class="option">
+                  <input type="radio" name="question9" value="a" />
+                  <span>Legacy on-premises file servers.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question9" value="b" />
+                  <span>Virtual private networks without authentication.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question9" value="c" />
+                  <span>Unsigned firmware updates on IoT devices.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question9" value="d" />
+                  <span>Endpoint detection and response (EDR) solutions.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+
+            <article class="quiz-card" data-answer="a" data-explanation="Tabletop exercises rehearse playbooks so leaders can practice decisions, communication, and coordination before an actual crisis.">
+              <fieldset>
+                <legend><span>10</span>How does a ransomware tabletop exercise help an organization?</legend>
+                <label class="option">
+                  <input type="radio" name="question10" value="a" />
+                  <span>It lets teams practice their roles and decisions before a real incident.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question10" value="b" />
+                  <span>It guarantees cyber insurance will cover any ransom payment.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question10" value="c" />
+                  <span>It replaces the need to maintain incident response plans.</span>
+                </label>
+                <label class="option">
+                  <input type="radio" name="question10" value="d" />
+                  <span>It eliminates the need for backups if everyone participates.</span>
+                </label>
+              </fieldset>
+              <p class="feedback" aria-live="polite"></p>
+            </article>
+          </div>
+
+          <div class="quiz-actions">
+            <button class="btn btn-primary" type="submit">Check my answers</button>
+            <button class="btn btn-secondary" type="reset">Reset quiz</button>
+          </div>
+          <div id="quiz-result" role="status" aria-live="polite"></div>
+        </form>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container">
+        <p>Keep learning with playbooks, training materials, and community-ready resources at <a href="index.html#learning-hub" style="color: inherit; text-decoration: underline;">What is Ransomware</a>.</p>
+      </div>
+    </footer>
+
+    <script>
+      const quizForm = document.getElementById('quiz-form');
+      const quizResult = document.getElementById('quiz-result');
+      const quizCards = Array.from(document.querySelectorAll('.quiz-card'));
+
+      quizForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        let score = 0;
+        let answered = 0;
+
+        quizCards.forEach((card, index) => {
+          const name = `question${index + 1}`;
+          const selected = quizForm.querySelector(`input[name="${name}"]:checked`);
+          const feedback = card.querySelector('.feedback');
+          const explanation = card.dataset.explanation;
+
+          card.classList.remove('is-correct', 'is-incorrect');
+
+          if (!selected) {
+            feedback.textContent = 'Select an answer to receive feedback.';
+            feedback.className = 'feedback pending';
+            return;
+          }
+
+          answered += 1;
+
+          if (selected.value === card.dataset.answer) {
+            score += 1;
+            feedback.textContent = `Correct — ${explanation}`;
+            feedback.className = 'feedback correct';
+            card.classList.add('is-correct');
+          } else {
+            feedback.textContent = `Incorrect — ${explanation}`;
+            feedback.className = 'feedback incorrect';
+            card.classList.add('is-incorrect');
+          }
+        });
+
+        if (answered < quizCards.length) {
+          quizResult.textContent = `You have answered ${answered} of ${quizCards.length} questions. Complete every question to see your total score.`;
+          return;
+        }
+
+        const message =
+          score === quizCards.length
+            ? 'Outstanding incident readiness!'
+            : score >= 8
+            ? 'Great work—just a couple of areas to fine-tune.'
+            : score >= 5
+            ? 'Good start. Review the learning hub topics to strengthen your response plan.'
+            : 'Consider revisiting the foundational lessons to build confidence against ransomware.';
+
+        quizResult.textContent = `You scored ${score} out of ${quizCards.length}. ${message}`;
+      });
+
+      quizForm.addEventListener('reset', () => {
+        quizResult.textContent = '';
+        quizCards.forEach((card) => {
+          card.classList.remove('is-correct', 'is-incorrect');
+          const feedback = card.querySelector('.feedback');
+          feedback.textContent = '';
+          feedback.className = 'feedback';
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new hero call-to-action button inviting visitors to take the ransomware quiz
- create a ransomware readiness quiz page with brand-aligned styling and navigation back to the learning hub
- implement interactive scoring and feedback for 10 ransomware knowledge questions with explanations

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd141275b88333b3e3e3257a5dd53e